### PR TITLE
Add experimental plugin reverse-import

### DIFF
--- a/packages/babel-plugin-syntax-reverse-import/.npmignore
+++ b/packages/babel-plugin-syntax-reverse-import/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+src

--- a/packages/babel-plugin-syntax-reverse-import/README.md
+++ b/packages/babel-plugin-syntax-reverse-import/README.md
@@ -1,0 +1,35 @@
+# @babel/plugin-syntax-reverse-import
+
+
+
+## Installation
+
+```sh
+npm install --save-dev @babel/plugin-syntax-reverse-impor
+```
+
+## Usage
+
+### Via `.babelrc` (Recommended)
+
+**.babelrc**
+
+```json
+{
+  "plugins": ["@babel/plugin-syntax-reverse-import"]
+}
+```
+
+### Via CLI
+
+```sh
+babel --plugins @babel/plugin-syntax-reverse-import script.js
+```
+
+### Via Node API
+
+```javascript
+require("@babel/core").transform("code", {
+  plugins: ["@babel/plugin-syntax-reverse-import"]
+});
+```

--- a/packages/babel-plugin-syntax-reverse-import/package.json
+++ b/packages/babel-plugin-syntax-reverse-import/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@babel/plugin-syntax-reverse-import",
+  "version": "7.0.0-beta.44",
+  "description": "Allow parsing of a reverse import statement",
+  "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-reverse-import",
+  "license": "MIT",
+  "main": "lib/index.js",
+  "keywords": [
+    "babel-plugin"
+  ],
+  "dependencies": {
+    "@babel/helper-plugin-utils": "7.0.0-beta.44"
+  },
+  "peerDependencies": {
+    "@babel/core": "7.0.0-beta.44"
+  },
+  "devDependencies": {
+    "@babel/core": "7.0.0-beta.44"
+  }
+}

--- a/packages/babel-plugin-syntax-reverse-import/src/index.js
+++ b/packages/babel-plugin-syntax-reverse-import/src/index.js
@@ -1,0 +1,11 @@
+import { declare } from "@babel/helper-plugin-utils";
+
+export default declare(api => {
+  api.assertVersion(7);
+
+  return {
+    manipulateOptions(opts, parserOpts) {
+      parserOpts.plugins.push("reverseImport");
+    },
+  };
+});

--- a/packages/babylon/src/index.js
+++ b/packages/babylon/src/index.js
@@ -12,10 +12,12 @@ import estreePlugin from "./plugins/estree";
 import flowPlugin from "./plugins/flow";
 import jsxPlugin from "./plugins/jsx";
 import typescriptPlugin from "./plugins/typescript";
+import reverseImportPlugin from "./plugins/reverse-import";
 plugins.estree = estreePlugin;
 plugins.flow = flowPlugin;
 plugins.jsx = jsxPlugin;
 plugins.typescript = typescriptPlugin;
+plugins.reverseImport = reverseImportPlugin;
 
 export function parse(input: string, options?: Options): File {
   if (options && options.sourceType === "unambiguous") {
@@ -73,7 +75,12 @@ function getParserClass(
 
   // Filter out just the plugins that have an actual mixin associated with them.
   let pluginList = pluginsFromOptions.filter(
-    p => p === "estree" || p === "flow" || p === "jsx" || p === "typescript",
+    p =>
+      p === "estree" ||
+      p === "flow" ||
+      p === "jsx" ||
+      p === "typescript" ||
+      p === "reverseImport",
   );
 
   if (pluginList.indexOf("flow") >= 0) {

--- a/packages/babylon/src/plugins/reverse-import.js
+++ b/packages/babylon/src/plugins/reverse-import.js
@@ -1,0 +1,89 @@
+// @flow
+
+import type Parser from "../parser";
+import { types as tt, keywords, TokenType } from "../tokenizer/types";
+import * as N from "../types";
+
+// TODO find a better place to add keyword
+keywords.from = new TokenType("from", { keyword: "from", startsExpr: true });
+tt._from = keywords.from;
+
+export default (superClass: Class<Parser>): Class<Parser> =>
+  class extends superClass {
+    isKeyword(name: string): boolean {
+      if (name === "import") {
+        return false;
+      } else if (name === "from") {
+        return true;
+      }
+      return super.isKeyword(name);
+    }
+
+    // eslint-disable-next-line no-unused-vars
+    shouldParseDefaultImportt(node: N.ImportDeclaration): boolean {
+      return this.match(tt.name);
+    }
+
+    parseImporttSpecifierLocal(
+      node: N.ImportDeclaration,
+      specifier: N.Node,
+      type: string,
+      contextDescription: string,
+    ): void {
+      specifier.local = this.parseIdentifier();
+      this.checkLVal(specifier.local, true, undefined, contextDescription);
+      node.specifiers.push(this.finishNode(specifier, type));
+    }
+
+    // Parses a comma-separated list of module imports.
+    parseImporttSpecifiers(node: N.ImportDeclaration): void {
+      if (this.shouldParseDefaultImportt(node)) {
+        // import defaultObj, { x, y as z } from '...'
+        this.parseImporttSpecifierLocal(
+          node,
+          this.startNode(),
+          "ImportDefaultSpecifier",
+          "default import specifier",
+        );
+
+        if (!this.eat(tt.comma)) return;
+      }
+    }
+
+    parseFromm(node: N.Node): N.ImportDeclaration {
+      // from ...
+      this.next();
+
+      node.source = this.match(tt.string)
+        ? this.parseExprAtom()
+        : this.unexpected;
+
+      this.expectContextual("import");
+
+      node.specifiers = [];
+      this.parseImporttSpecifiers(node);
+
+      this.semicolon();
+      return this.finishNode(node, "ImportDeclaration");
+    }
+
+    parseStatementContent(
+      declaration: boolean,
+      topLevel: ?boolean,
+    ): N.Statement {
+      const starttype = this.state.type;
+      const node = this.startNode();
+
+      if (starttype === tt._from) {
+        const result = this.parseFromm(node);
+
+        this.assertModuleNodeAllowed(node);
+
+        return result;
+      } else if (starttype === tt._import) {
+        this.unexpected();
+      }
+
+      return super.parseStatementContent(declaration, topLevel);
+    }
+  };

--- a/packages/babylon/test/fixtures/reverse-import/basic/default/input.js
+++ b/packages/babylon/test/fixtures/reverse-import/basic/default/input.js
@@ -1,0 +1,1 @@
+from "mymodule" import func;

--- a/packages/babylon/test/fixtures/reverse-import/basic/default/output.json
+++ b/packages/babylon/test/fixtures/reverse-import/basic/default/output.json
@@ -1,0 +1,103 @@
+{
+  "type": "File",
+  "start": 0,
+  "end": 28,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 28
+    }
+  },
+  "program": {
+    "type": "Program",
+    "start": 0,
+    "end": 28,
+    "loc": {
+      "start": {
+        "line": 1,
+        "column": 0
+      },
+      "end": {
+        "line": 1,
+        "column": 28
+      }
+    },
+    "sourceType": "module",
+    "body": [
+      {
+        "type": "ImportDeclaration",
+        "start": 0,
+        "end": 28,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 28
+          }
+        },
+        "source": {
+          "type": "StringLiteral",
+          "start": 5,
+          "end": 15,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 15
+            }
+          },
+          "extra": {
+            "rawValue": "mymodule",
+            "raw": "\"mymodule\""
+          },
+          "value": "mymodule"
+        },
+        "specifiers": [
+          {
+            "type": "ImportDefaultSpecifier",
+            "start": 23,
+            "end": 27,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 23
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            "local": {
+              "type": "Identifier",
+              "start": 23,
+              "end": 27,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 23
+                },
+                "end": {
+                  "line": 1,
+                  "column": 27
+                },
+                "identifierName": "func"
+              },
+              "name": "func"
+            }
+          }
+        ]
+      }
+    ],
+    "directives": []
+  }
+}

--- a/packages/babylon/test/fixtures/reverse-import/options.json
+++ b/packages/babylon/test/fixtures/reverse-import/options.json
@@ -1,0 +1,4 @@
+{
+  "sourceType": "module",
+  "plugins": ["reverseImport"]
+}


### PR DESCRIPTION
`babel-plugin-syntax-reverse-import` allows babel to parse import statements that look like so
`from "module" import { foo, bar as baz }`